### PR TITLE
fix(deps): use latest version of gundeck-action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ inputs:
     required: true
   docker-image:
     description: dockerimage used to run rundeck
-    default: eu.gcr.io/tradeshift-public/gundeck-action:1.0.0
+    default: eu.gcr.io/tradeshift-public/gundeck-action:latest
 runs:
   using: node16
   main: dist/index.js


### PR DESCRIPTION
We can test new gundeck releases before made them available. 
By setting here latest we make sure that we'll use the latest tested version.